### PR TITLE
fix(checkbox): click bug on safari

### DIFF
--- a/projects/ng-verse/src/lib/checkbox/checkbox.component.scss
+++ b/projects/ng-verse/src/lib/checkbox/checkbox.component.scss
@@ -54,6 +54,8 @@
   right: 0;
   bottom: 0;
   top: 0;
+  width: 100%;
+  height: 100%;
   z-index: 1;
   &:focus-visible + .checkbox-icon {
     outline: 1px solid var(--nv-ring);


### PR DESCRIPTION
Stretch native checkbox to the container with 100% and height 100%. Safari doesn't stretch with top,left... props